### PR TITLE
Added top‑3 product price trend and (optional) PED analysis to trend_test.py

### DIFF
--- a/Data Analysis/trend_test.py
+++ b/Data Analysis/trend_test.py
@@ -74,3 +74,74 @@ if not monthly_sale_counts.empty:
     plt.show()
 else:
     print("No sales (price drops) detected for this product — monthly sales frequency plot not generated.")
+
+import numpy as np
+
+# --- Top-3 price trend comparison (non-intrusive) ---
+try:
+    sr_top3_products = df['product_id'].value_counts().head(3).index.tolist()
+    if len(sr_top3_products) > 0:
+        plt.figure(figsize=(12, 6))
+        for _pid in sr_top3_products:
+            _prod = df[df['product_id'] == _pid].copy()
+            _prod = _prod.sort_values('date')
+            plt.plot(_prod['date'], _prod['price'], marker='o', linestyle='--', label=f'Product {str(_pid)[:6]}')
+        plt.title("Price Comparison for Top 3 Products")
+        plt.xlabel("Date")
+        plt.ylabel("Price ($)")
+        plt.legend()
+        plt.grid(True, linestyle='--', alpha=0.5)
+        plt.xticks(rotation=45)
+        plt.tight_layout()
+        plt.show()
+    else:
+        print("[Top-3 Trend] Skipped: not enough products.")
+except Exception as e:
+    print(f"[Top-3 Trend] Skipped due to error: {e}")
+
+# --- Optional: Price Elasticity of Demand (PED) if quantity exists ---
+# PED ≈ dln(Q) / dln(P) -> estimated via simple log-log slope per product.
+if 'quantity' in df.columns:
+    try:
+        sr_ped = df[(df['price'] > 0) & (df['quantity'] > 0)].copy()
+        sr_ped['log_price'] = np.log(sr_ped['price'])
+        sr_ped['log_qty']   = np.log(sr_ped['quantity'])
+
+        def _ped_slope(g):
+            x = g['log_price'].values
+            y = g['log_qty'].values
+            if len(x) < 2 or np.var(x) == 0:
+                return np.nan
+            # OLS slope for y~x using covariance/variance
+            return np.cov(x, y, ddof=0)[0, 1] / np.var(x)
+
+        sr_ped_by_product = (
+            sr_ped.groupby('product_id')
+                  .apply(_ped_slope)
+                  .reset_index(name='ped_slope')
+                  .dropna()
+        )
+
+        # Interpret: more negative -> more price-sensitive (elastic)
+        sr_ped_by_product['interpretation'] = np.where(
+            sr_ped_by_product['ped_slope'] <= -1, 'elastic (price-sensitive)',
+            np.where(sr_ped_by_product['ped_slope'] < 0, 'inelastic (price-insensitive)', 'no relationship')
+        )
+
+        print("\n[PED] Estimated elasticity (dlnQ/dlnP) by product (most elastic first):")
+        print(sr_ped_by_product.sort_values('ped_slope').head(10))
+
+        # Quick viz for Top-5 most elastic products
+        _top = sr_ped_by_product.sort_values('ped_slope').head(5)
+        if not _top.empty:
+            plt.figure(figsize=(8, 5))
+            plt.barh(_top['product_id'].astype(str).str[:8], _top['ped_slope'])
+            plt.title("Most Elastic Products (more negative = more sensitive)")
+            plt.xlabel("PED (slope dlnQ/dlnP)")
+            plt.grid(axis='x', linestyle='--', alpha=0.5)
+            plt.tight_layout()
+            plt.show()
+    except Exception as e:
+        print(f"[PED] Could not compute elasticity: {e}")
+else:
+    print("[PED] Skipped: 'quantity' column not present in dataset.")


### PR DESCRIPTION
- Added top‑3 product price trend comparison (non-intrusive).
- Kept existing volatility/sales logic intact.
- Optional PED estimates only run if 'quantity' exists; otherwise skipped.
- Tested locally with AugmentedData.product_pricing.csv.
