### PR TITLE
Added a rateLimit function for Signups

### DIFF
--- a/Backend/package-lock.json
+++ b/Backend/package-lock.json
@@ -16,6 +16,7 @@
         "dotenv": "^16.5.0",
         "env": "^0.0.2",
         "express": "^4.20.0",
+        "express-rate-limit": "^8.1.0",
         "firebase": "^10.13.0",
         "firebase-admin": "^12.4.0",
         "jsonwebtoken": "^9.0.2",
@@ -2948,6 +2949,24 @@
         "node": ">= 0.10.0"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.1.0.tgz",
+      "integrity": "sha512-4nLnATuKupnmwqiJc27b4dCFmB/T60ExgmtDD7waf4LdrbJ8CPZzZRHYErDYNhoz+ql8fUdYwM/opf90PoPAQA==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.0.1"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/express/node_modules/qs": {
       "version": "6.11.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
@@ -3967,6 +3986,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
+      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/ipaddr.js": {

--- a/Backend/package.json
+++ b/Backend/package.json
@@ -23,6 +23,7 @@
     "dotenv": "^16.5.0",
     "env": "^0.0.2",
     "express": "^4.20.0",
+    "express-rate-limit": "^8.1.0",
     "firebase": "^10.13.0",
     "firebase-admin": "^12.4.0",
     "jsonwebtoken": "^9.0.2",

--- a/Backend/src/controllers/user.controller.js
+++ b/Backend/src/controllers/user.controller.js
@@ -46,6 +46,23 @@ const signup = async (req, res) => {
     }
 };
 
+// Defining the limiter 
+const { rateLimit } = require("express-rate-limit"); 
+
+// Only allows for one request every 5 minutes per IP
+const limiter = rateLimit({ 
+
+windowMs: 5 * 60 * 1000, 
+
+limit: 1, 
+
+message: "Too many requests. Please try again later.", 
+
+standardHeaders: true, 
+
+legacyHeaders: false, 
+
+}); 
 
 // Signin Controller
 const signin = async (req, res) => {

--- a/Backend/src/routers/user.router.js
+++ b/Backend/src/routers/user.router.js
@@ -67,7 +67,7 @@ const router = express.Router();
  *       500:
  *         description: Internal server error
  */
-router.post('/signup', userController.signup);
+router.post('/signup', userController.signupLimiter, userController.signup); // Signup using limiter
 
 // Signin route
 /**

--- a/Backend/yarn.lock
+++ b/Backend/yarn.lock
@@ -1730,7 +1730,14 @@ event-target-shim@^5.0.0:
   resolved "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz"
   integrity sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==
 
-express@^4.20.0, "express@>=4.0.0 || >=5.0.0-beta":
+express-rate-limit@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.1.0.tgz"
+  integrity sha512-4nLnATuKupnmwqiJc27b4dCFmB/T60ExgmtDD7waf4LdrbJ8CPZzZRHYErDYNhoz+ql8fUdYwM/opf90PoPAQA==
+  dependencies:
+    ip-address "10.0.1"
+
+express@^4.20.0, "express@>= 4.11", "express@>=4.0.0 || >=5.0.0-beta":
   version "4.20.0"
   resolved "https://registry.npmjs.org/express/-/express-4.20.0.tgz"
   integrity sha512-pLdae7I6QqShF5PnNTCVn4hI91Dx0Grkn2+IAsMTgMIKuQVte2dN9PeGSSAME2FR8anOhVA62QDIUaWVfEXVLw==
@@ -2300,6 +2307,11 @@ internal-slot@^1.0.7:
     es-errors "^1.3.0"
     hasown "^2.0.0"
     side-channel "^1.0.4"
+
+ip-address@10.0.1:
+  version "10.0.1"
+  resolved "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz"
+  integrity sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==
 
 ipaddr.js@1.9.1:
   version "1.9.1"


### PR DESCRIPTION
Installed npm express-rate-limit and created a ‘rateLimit’ function which effectively only allows for 1 signup request every 5 minutes per IP address to protect against flooding attacks. Updated the sign-up route in user.router.js to include this rate limiter function.