### PR TITLE
feat: Support ml service local model load

### DIFF
--- a/Backend/.env.example
+++ b/Backend/.env.example
@@ -12,8 +12,12 @@ SUPPORT_EMAIL_APP_PASSWORD=
 
 RIS_STARTUP_TIMEOUT_MS=300000
 
-# Google Cloud / FAISS reverse image search
-# Fill this with your DiscountMate GCP project ID for local Google Cloud access.
+# Use local artifacts during development. Set to gcs in deployed environments.
+MODEL_ARTIFACT_SOURCE=local
+LOCAL_FAISS_PATH=
+LOCAL_RAG_INDEX_DIR=
+
+# Google Cloud artifact storage (used when MODEL_ARTIFACT_SOURCE=gcs)
 GOOGLE_CLOUD_PROJECT=sit-26t1-discountmate-935cb94
 MONGO_URI_SECRET_NAME=mongo-uri
 JWT_SECRET_SECRET_NAME=jwt-secret

--- a/Backend/ml-service/README.md
+++ b/Backend/ml-service/README.md
@@ -255,7 +255,7 @@ The reverse image search feature lives in `reverse_image_search/` inside this se
 1. User uploads a product image via the Node.js API (`POST /api/reverse-image-search`)
 2. Node.js proxies the image to the FastAPI sidecar on port 8001
 3. The sidecar extracts a 768-dim embedding using **DINOv2 ViT-B/14** with 5 test-time augmentations
-4. A prebuilt **FAISS HNSW index** is downloaded from Google Cloud Storage on startup and cached locally
+4. A prebuilt **FAISS HNSW index** is loaded from the local device or downloaded from Google Cloud Storage
 5. Results are deduplicated by product and ranked by similarity score
 6. Node.js enriches the results with live pricing from MongoDB before returning them
 
@@ -268,13 +268,25 @@ The reverse image search feature lives in `reverse_image_search/` inside this se
 | `ml_models/reverse_image_search.faiss` | Local development cache for the downloaded FAISS HNSW index; ignored by Git |
 | `ml_models/reverse_image_search_metadata.json` | Product metadata for each indexed vector (~33 MB) |
 
-### FAISS index download
+### Model artifact source
 
-The FAISS index is not stored in Git. On startup, `reverse_image_search/notebook_runtime.py` downloads it from Google Cloud Storage if the cache file is missing.
-
-Configure these values in `Backend/.env`:
+The large FAISS and Recipe RAG index files are not stored in Git. Select their source in `Backend/.env`:
 
 ```env
+# Local development: never contact GCS for model artifacts
+MODEL_ARTIFACT_SOURCE=local
+LOCAL_FAISS_PATH=/absolute/path/to/reverse_image_search.faiss
+LOCAL_RAG_INDEX_DIR=/absolute/path/to/recipe_rag/index
+```
+
+`LOCAL_RAG_INDEX_DIR` must contain `recipe_index.npz`, `recipe_metadata.json`, `product_index.npz`, and `product_metadata.json`. If either path override is omitted, the service uses the ignored project directories `ml_models/` and `recipe_rag/index/`.
+
+When a local artifact is missing or invalid, the affected feature reports itself as unavailable instead of contacting GCS. The remaining services continue to run. Reverse-image health returns HTTP 200 with `"ready": false`, while search and unavailable Recipe RAG endpoints return HTTP 503.
+
+For deployed environments, use the existing cache-first GCS behavior:
+
+```env
+MODEL_ARTIFACT_SOURCE=gcs
 GOOGLE_CLOUD_PROJECT=your-gcp-project-id
 FAISS_GCP_PROJECT=
 FAISS_QUOTA_PROJECT=
@@ -292,7 +304,7 @@ Default cache paths:
 | Local machine | `Backend/ml-service/ml_models/reverse_image_search.faiss` |
 | Cloud Run / App Engine | `/tmp/reverse_image_search.faiss` |
 
-You can override the cache path with `LOCAL_FAISS_PATH`.
+You can override the cache paths with `LOCAL_FAISS_PATH` and `LOCAL_RAG_INDEX_DIR`.
 
 For local GCS access, authenticate once:
 
@@ -304,7 +316,7 @@ gcloud auth application-default set-quota-project your-gcp-project-id
 
 ### First-run note
 
-On first startup, DINOv2 (~330 MB) is downloaded from Torch Hub and the FAISS index is downloaded from GCS. This can take a few minutes. Subsequent runs use the local caches.
+On first startup, DINOv2 (~330 MB) is downloaded from Torch Hub. In `gcs` mode, missing index artifacts are also downloaded from GCS. Subsequent runs use the local caches.
 
 ### Rebuilding the index
 

--- a/Backend/ml-service/app.py
+++ b/Backend/ml-service/app.py
@@ -76,7 +76,8 @@ ensure_runtime_secrets()
 # ============================================================
 # Recipe RAG initialisation
 # ============================================================
-from recipe_rag.rag_pipeline import RecipeRAG
+from recipe_rag.gcs_loader import MODEL_ARTIFACT_SOURCE
+from recipe_rag.rag_pipeline import INDEX_DIR, RecipeRAG
 
 rag = None
 RAG_INIT_ERROR = None
@@ -337,6 +338,8 @@ def recipe_stats():
             'success': True,
             'ready': False,
             'loaded': False,
+            'model_source': MODEL_ARTIFACT_SOURCE,
+            'index_dir': INDEX_DIR,
         }
         if RAG_INIT_ERROR is not None:
             payload['error'] = str(RAG_INIT_ERROR)
@@ -345,6 +348,8 @@ def recipe_stats():
     return jsonify({
         'success': True,
         'ready': True,
+        'model_source': MODEL_ARTIFACT_SOURCE,
+        'index_dir': INDEX_DIR,
         'recipe_count': len(rag.retriever.recipes),
         'active_sessions': len(rag.sessions),
         'max_turns_per_session': rag.max_turns,

--- a/Backend/ml-service/recipe_rag/gcs_loader.py
+++ b/Backend/ml-service/recipe_rag/gcs_loader.py
@@ -1,15 +1,13 @@
 """
-GCS loader for RAG index files.
+Local/GCS loader for RAG index files.
 
 Binary index artefacts live in the team's existing GCS bucket
 (discountmate-ml-models) under a recipe_rag/ prefix, and are
 downloaded to a local cache on first run.
 
-Behaviour by environment:
-  - LOCAL DEV:        if a file already exists at the expected local
-                      path, it is used as-is (no download). Only files
-                      that are MISSING locally trigger a GCS fetch.
-  - CLOUD RUN / GAE:  cache directory defaults to /tmp/recipe_rag/.
+Behaviour by source:
+  - local:            use local files only; never contact GCS.
+  - gcs:              use cached local files, downloading missing files.
 
 Required env vars (already set in Backend/.env):
   GOOGLE_CLOUD_PROJECT       sit-26t1-discountmate-935cb94
@@ -54,6 +52,7 @@ INDEX_FILES = [
 RAG_BUCKET_NAME = os.environ.get("RAG_BUCKET_NAME", "discountmate-ml-models")
 RAG_OBJECT_PREFIX = os.environ.get("RAG_OBJECT_PREFIX", "recipe_rag/")
 RAG_GCP_PROJECT = os.environ.get("GOOGLE_CLOUD_PROJECT")
+MODEL_ARTIFACT_SOURCE = os.environ.get("MODEL_ARTIFACT_SOURCE", "gcs").strip().lower()
 
 
 # ---------------------------------------------------------------------------
@@ -67,11 +66,21 @@ def _is_gcp_serverless() -> bool:
 
 def _resolve_local_index_dir() -> Path:
     """Where the index files should live on this machine."""
+    if override := os.environ.get("LOCAL_RAG_INDEX_DIR"):
+        return Path(override)
     if _is_gcp_serverless():
         return Path("/tmp") / "recipe_rag"
     # Default: same place rag_pipeline.py already expects
     # (Backend/ml-service/recipe_rag/index/)
     return Path(__file__).resolve().parent / "index"
+
+
+def _validate_artifact_source() -> None:
+    if MODEL_ARTIFACT_SOURCE not in {"gcs", "local"}:
+        raise RuntimeError(
+            "MODEL_ARTIFACT_SOURCE must be either 'gcs' or 'local', "
+            f"got {MODEL_ARTIFACT_SOURCE!r}."
+        )
 
 
 def _download_one(blob_name: str, dest_path: Path) -> None:
@@ -133,11 +142,19 @@ def ensure_index_file(filename: str,
 
     Safe to call repeatedly — it's a no-op when the file is already present.
     """
+    _validate_artifact_source()
     target_dir = Path(index_dir) if index_dir else _resolve_local_index_dir()
     local_path = target_dir / filename
 
     if local_path.exists():
         return str(local_path)
+
+    if MODEL_ARTIFACT_SOURCE == "local":
+        raise RuntimeError(
+            "Recipe RAG artifact is missing in local mode at "
+            f"'{local_path}'. Set LOCAL_RAG_INDEX_DIR to the directory "
+            "containing the required index files."
+        )
 
     blob_name = f"{RAG_OBJECT_PREFIX}{filename}"
     _download_one(blob_name, local_path)
@@ -145,11 +162,17 @@ def ensure_index_file(filename: str,
 
 
 def ensure_all_indexes(index_dir: Optional[str] = None) -> None:
-    """Ensure every file in INDEX_FILES is present locally, downloading in parallel."""
+    """Ensure every file in INDEX_FILES is available from the configured source."""
+    _validate_artifact_source()
     target_dir = Path(index_dir) if index_dir else _resolve_local_index_dir()
     missing = [f for f in INDEX_FILES if not (target_dir / f).exists()]
     if not missing:
         return
+    if MODEL_ARTIFACT_SOURCE == "local":
+        missing_paths = ", ".join(str(target_dir / filename) for filename in missing)
+        raise RuntimeError(
+            f"Recipe RAG artifacts are missing in local mode: {missing_paths}"
+        )
     print(f"[gcs_loader] {len(missing)} file(s) missing locally, "
           f"fetching from GCS in parallel: {missing}")
     with ThreadPoolExecutor(max_workers=min(len(missing), 4)) as executor:

--- a/Backend/ml-service/recipe_rag/rag_pipeline.py
+++ b/Backend/ml-service/recipe_rag/rag_pipeline.py
@@ -30,9 +30,15 @@ except ImportError:
           "Run: pip install sentence-transformers")
 
 try:
-    from .gcs_loader import ensure_index_file   # Flask package
+    from .gcs_loader import (  # Flask package
+        ensure_index_file,
+        get_local_index_dir,
+    )
 except ImportError:
-    from gcs_loader import ensure_index_file    # CLI direct run
+    from gcs_loader import (  # CLI direct run
+        ensure_index_file,
+        get_local_index_dir,
+    )
 
 # ---------------------------------------------------------------------------
 # Configuration
@@ -53,7 +59,7 @@ else:
     print(f"[env] no .env at {_ENV_PATH} — fell back to cwd search")
 
 EMBEDDING_MODEL_NAME = "all-mpnet-base-v2"
-INDEX_DIR = os.path.join(os.path.dirname(__file__), "index")
+INDEX_DIR = get_local_index_dir()
 
 OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions"
 HUGGINGFACE_URL = "https://router.huggingface.co/v1/chat/completions"
@@ -883,8 +889,8 @@ class RecipeRetriever:
             meta_path = ensure_index_file("recipe_metadata.json", self.index_dir)
         except RuntimeError as e:
             raise FileNotFoundError(
-                f"Recipe index unavailable (local + GCS both failed): {e}\n"
-                "Run: python build_recipe_index.py — or check GCS auth."
+                f"Recipe index unavailable from the configured source: {e}\n"
+                "Build the local index or check the configured GCS access."
             ) from e
         embeddings = np.load(emb_path)["embeddings"].astype(np.float32)
         with open(meta_path, "r", encoding="utf-8") as f:
@@ -972,13 +978,18 @@ class ProductMatcher:
             meta_path = ensure_index_file("product_metadata.json", self.index_dir)
         except RuntimeError as e:
             print(f"[ProductMatcher] product index unavailable "
-                  f"(local + GCS both failed) — annotations DISABLED. {e}")
+                  f"from the configured source — annotations DISABLED. {e}")
             return
 
-        data = np.load(emb_path, allow_pickle=True)
-        embeddings = data["embeddings"].astype(np.float32)
-        with open(meta_path, "r", encoding="utf-8") as f:
-            products = json.load(f)["products"]
+        try:
+            data = np.load(emb_path, allow_pickle=True)
+            embeddings = data["embeddings"].astype(np.float32)
+            with open(meta_path, "r", encoding="utf-8") as f:
+                products = json.load(f)["products"]
+        except Exception as e:
+            print(f"[ProductMatcher] product index is invalid "
+                  f"— annotations DISABLED. {e}")
+            return
 
         if embeddings.shape[0] != len(products):
             print(f"[ProductMatcher] WARNING: shape mismatch — "

--- a/Backend/ml-service/reverse_image_search/api.py
+++ b/Backend/ml-service/reverse_image_search/api.py
@@ -10,6 +10,7 @@ import os
 os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "TRUE")
 
 import io
+import sys
 from contextlib import asynccontextmanager
 from typing import Optional
 
@@ -17,11 +18,12 @@ import cv2
 import numpy as np
 from PIL import Image
 
-from fastapi import FastAPI, File, HTTPException, UploadFile
+from fastapi import FastAPI, File, HTTPException, Request, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 
 from notebook_runtime import (
+    MODEL_ARTIFACT_SOURCE,
     METADATA_PATH,
     load_engine,
     search_image_array,
@@ -32,9 +34,21 @@ MAX_UPLOAD_BYTES = 10 * 1024 * 1024  # 10 MB
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    if not METADATA_PATH.exists():
-        raise RuntimeError(f"Metadata not found at '{METADATA_PATH}'.")
-    load_engine()
+    app.state.model_ready = False
+    app.state.model_error = None
+    try:
+        if not METADATA_PATH.exists():
+            raise RuntimeError(f"Metadata not found at '{METADATA_PATH}'.")
+        load_engine()
+        app.state.model_ready = True
+    except Exception as exc:
+        if MODEL_ARTIFACT_SOURCE == "gcs":
+            raise
+        app.state.model_error = str(exc)
+        print(
+            f"[ReverseImageSearch] feature disabled: {exc}",
+            file=sys.stderr,
+        )
     yield
 
 
@@ -71,9 +85,16 @@ def _clean_price(val) -> Optional[str]:
 
 @app.post("/reverse-image-search", response_model=list[SearchResult])
 async def reverse_image_search(
+    request: Request,
     file: UploadFile = File(...),
     top_k: int = 5,
 ) -> list[SearchResult]:
+    if not getattr(request.app.state, "model_ready", False):
+        error = getattr(request.app.state, "model_error", None)
+        raise HTTPException(
+            status_code=503,
+            detail=f"Reverse image search is unavailable: {error or 'model is not ready'}",
+        )
     if not (1 <= top_k <= 20):
         raise HTTPException(status_code=400, detail="top_k must be between 1 and 20.")
     if not file.content_type or not file.content_type.startswith("image/"):
@@ -117,5 +138,13 @@ async def reverse_image_search(
 
 
 @app.get("/health")
-async def health() -> dict:
-    return {"status": "ok"}
+async def health(request: Request) -> dict:
+    ready = getattr(request.app.state, "model_ready", False)
+    payload = {
+        "status": "ok" if ready else "degraded",
+        "ready": ready,
+        "model_source": MODEL_ARTIFACT_SOURCE,
+    }
+    if error := getattr(request.app.state, "model_error", None):
+        payload["error"] = error
+    return payload

--- a/Backend/ml-service/reverse_image_search/notebook_runtime.py
+++ b/Backend/ml-service/reverse_image_search/notebook_runtime.py
@@ -1,7 +1,7 @@
 """
 Query-only runtime extracted from the reverse-image-search Jupyter notebook.
 
-Loads reverse-image-search metadata plus the FAISS index cached from GCS, and
+Loads reverse-image-search metadata plus a local or GCS-backed FAISS index, and
 exposes two entrypoints for reverse-image search:
 
     search_image_file(image_path, top_k=3)    -> list[dict]
@@ -22,9 +22,7 @@ import sys
 from pathlib import Path
 from typing import Optional, cast
 
-import google.auth
 from dotenv import load_dotenv
-from google.cloud.storage import Client as StorageClient  # pyright: ignore[reportMissingImports]
 
 # torch MUST be imported before faiss (OpenMP runtime claim — see notebook).
 import torch
@@ -49,8 +47,9 @@ TEST_IMAGE_DIR = BASE_DIR / "Test_Image"
 load_dotenv(BASE_DIR.parent.parent / ".env", override=False)
 
 # ---------------------------------------------------------------------------
-# GCS config — override via env vars if needed
+# Model artifact config
 # ---------------------------------------------------------------------------
+MODEL_ARTIFACT_SOURCE = os.environ.get("MODEL_ARTIFACT_SOURCE", "gcs").strip().lower()
 FAISS_BUCKET_NAME = os.environ.get("FAISS_BUCKET_NAME", "discountmate-ml-models")
 FAISS_OBJECT_NAME = os.environ.get("FAISS_OBJECT_NAME", "reverse_image_search.faiss")
 FAISS_GCP_PROJECT = (
@@ -77,8 +76,19 @@ def _is_gcp_serverless() -> bool:
 INDEX_PATH = _resolve_faiss_local_path()
 
 
-def load_faiss_index_from_gcs() -> Path:
-    """Download the FAISS index from GCS if not already cached locally."""
+def _validate_artifact_source() -> None:
+    if MODEL_ARTIFACT_SOURCE not in {"gcs", "local"}:
+        raise RuntimeError(
+            "MODEL_ARTIFACT_SOURCE must be either 'gcs' or 'local', "
+            f"got {MODEL_ARTIFACT_SOURCE!r}."
+        )
+
+
+def _download_faiss_index_from_gcs() -> Path:
+    """Download the FAISS index to the configured local cache path."""
+    import google.auth
+    from google.cloud.storage import Client as StorageClient  # pyright: ignore[reportMissingImports]
+
     if INDEX_PATH.exists():
         return INDEX_PATH
     INDEX_PATH.parent.mkdir(parents=True, exist_ok=True)
@@ -117,6 +127,20 @@ def load_faiss_index_from_gcs() -> Path:
             "`gcloud auth application-default set-quota-project <project-id>`."
         ) from exc
     return INDEX_PATH
+
+
+def resolve_faiss_index() -> Path:
+    """Resolve the FAISS index without contacting GCS in local mode."""
+    _validate_artifact_source()
+    if INDEX_PATH.exists():
+        return INDEX_PATH
+    if MODEL_ARTIFACT_SOURCE == "local":
+        raise RuntimeError(
+            "Reverse image search is unavailable because the local FAISS "
+            f"index is missing at '{INDEX_PATH}'. Set LOCAL_FAISS_PATH to a "
+            "valid index file or place the artifact at the default path."
+        )
+    return _download_faiss_index_from_gcs()
 
 # ---------------------------------------------------------------------------
 # Config — mirrors notebook defaults that produced the shipped index.
@@ -306,13 +330,13 @@ def load_engine(device: Optional[str] = None) -> dict:
             "Expected a prebuilt metadata file alongside the runtime module."
         )
 
-    resolved_index = load_faiss_index_from_gcs()
+    resolved_index = resolve_faiss_index()
     try:
         index = faiss.read_index(str(resolved_index))
     except Exception as exc:
         raise RuntimeError(
             f"Failed to load FAISS index from '{resolved_index}': {exc}. "
-            "Delete the cached file and restart to download a fresh copy."
+            "Replace or rebuild the configured index artifact."
         ) from exc
     if index.d != VECTOR_DIM:
         raise ValueError(
@@ -324,7 +348,7 @@ def load_engine(device: Optional[str] = None) -> dict:
         print(
             "[ReverseImageSearch] WARNING: FAISS index contains 0 vectors — "
             "all searches will return empty results. "
-            "Upload the correct index to GCS and delete the local cache to re-download.",
+            "Replace or rebuild the configured index artifact.",
             file=sys.stderr,
         )
     with open(METADATA_PATH, encoding="utf-8") as f:

--- a/Backend/src/services/reverseImageSearchProcess.js
+++ b/Backend/src/services/reverseImageSearchProcess.js
@@ -43,10 +43,22 @@ function checkHealth() {
   return new Promise((resolve) => {
     const req = http.request(
       { hostname: RIS_HOST, port: RIS_PORT, path: '/health', method: 'GET', timeout: 3000 },
-      (res) => { res.resume(); resolve(res.statusCode === 200); }
+      (res) => {
+        let body = '';
+        res.setEncoding('utf8');
+        res.on('data', (chunk) => { body += chunk; });
+        res.on('end', () => {
+          if (res.statusCode !== 200) return resolve(null);
+          try {
+            return resolve(JSON.parse(body));
+          } catch {
+            return resolve({ ready: true });
+          }
+        });
+      }
     );
-    req.on('error',   () => resolve(false));
-    req.on('timeout', () => { req.destroy(); resolve(false); });
+    req.on('error',   () => resolve(null));
+    req.on('timeout', () => { req.destroy(); resolve(null); });
     req.end();
   });
 }
@@ -94,9 +106,13 @@ function startReverseImageSearch() {
           `[ReverseImageSearch] Did not become healthy within ${timeoutMs / 1000} s.`
         ));
       }
-      checkHealth().then((ok) => {
-        if (ok) {
-          console.log('[ReverseImageSearch] Sidecar is healthy and ready.');
+      checkHealth().then((health) => {
+        if (health) {
+          if (health.ready === false) {
+            console.warn(`[ReverseImageSearch] Sidecar is running but search is unavailable: ${health.error || 'model is not ready'}`);
+          } else {
+            console.log('[ReverseImageSearch] Sidecar is healthy and ready.');
+          }
           _proc.on('exit', (code) => {
             console.error(`[ReverseImageSearch] Sidecar exited unexpectedly (code ${code}). Restart the server to recover.`);
             _proc = null;

--- a/SETUP.md
+++ b/SETUP.md
@@ -73,11 +73,13 @@ BASE_URL=http://localhost:3000
 MONGO_URI=your_mongodb_connection_string
 JWT_SECRET=a_long_random_string
 
-# Google Cloud (required for FAISS index download on first run)
-GOOGLE_CLOUD_PROJECT=your-gcp-project-id
-FAISS_BUCKET_NAME=discountmate-ml-models
-FAISS_OBJECT_NAME=reverse_image_search.faiss
+# Local model artifacts (no GCS access required)
+MODEL_ARTIFACT_SOURCE=local
+LOCAL_FAISS_PATH=/absolute/path/to/reverse_image_search.faiss
+LOCAL_RAG_INDEX_DIR=/absolute/path/to/recipe_rag/index
 ```
+
+`LOCAL_RAG_INDEX_DIR` must contain `recipe_index.npz`, `recipe_metadata.json`, `product_index.npz`, and `product_metadata.json`. You can omit either path override to use the ignored default directories under `Backend/ml-service/`.
 
 Generate `JWT_SECRET` with Node.js:
 
@@ -141,7 +143,7 @@ cd Backend
 node server.js
 ```
 
-> `node server.js` automatically downloads the FAISS index from GCS on first run (cached at `Backend/ml-service/ml_models/reverse_image_search.faiss`) and spawns the Reverse Image Search FastAPI sidecar on port 8001 before accepting any requests. No separate terminal is needed for the sidecar.
+> `node server.js` automatically spawns the Reverse Image Search FastAPI sidecar on port 8001. In local artifact mode, a missing index leaves the sidecar running in a degraded state instead of blocking the Node backend.
 
 **Terminal 3 — Frontend**
 ```bash
@@ -169,14 +171,14 @@ curl -X POST "http://localhost:3000/api/reverse-image-search" \
   -F "file=@/path/to/any-product-image.jpg"
 ```
 
-All four commands should return HTTP 200. If the sidecar health check fails, wait up to 5 minutes for the first-run DINOv2 and FAISS downloads to complete.
+The service health commands should return HTTP 200. Reverse-image health includes a `ready` field; `false` means the sidecar is running but its local artifact is unavailable. Search requests return HTTP 503 until a valid artifact is configured.
 
 ### First-run note
 
-The first `node server.js` run triggers two large downloads automatically:
+The first `node server.js` run may download DINOv2 (~330 MB) from PyTorch Hub into the Torch Hub cache directory. Model index behavior depends on `MODEL_ARTIFACT_SOURCE`:
 
-1. **DINOv2 model** (~330 MB) — downloaded from PyTorch Hub into the Torch Hub cache directory
-2. **FAISS index** — downloaded from GCS to `Backend/ml-service/ml_models/reverse_image_search.faiss`
+- `local`: load FAISS and Recipe RAG indexes only from the configured device paths.
+- `gcs`: use cached local indexes first, then download missing artifacts from GCS.
 
 Subsequent runs use the local caches and start in seconds.
 
@@ -290,13 +292,14 @@ Set these in `Backend/.env` for local development. In production, `MONGO_URI` an
 | `JWT_SECRET` | Backend | Yes (local) | — | Secret key for signing JWTs. Loaded from Secret Manager in production. | `some-long-random-value` |
 | `MONGO_URI_SECRET_NAME` | Backend | No | `mongo-uri` | Secret Manager name for `MONGO_URI` | `mongo-uri` |
 | `JWT_SECRET_SECRET_NAME` | Backend | No | `jwt-secret` | Secret Manager name for `JWT_SECRET` | `jwt-secret` |
-| `GOOGLE_CLOUD_PROJECT` | Backend + Sidecar | Yes | — | GCP project ID. Required for Secret Manager (production) and GCS (all envs). | `my-project-123` |
+| `GOOGLE_CLOUD_PROJECT` | Backend + Sidecar | Conditional | — | Required for Secret Manager in production and for model artifacts in `gcs` mode. | `my-project-123` |
 | `UPLOAD_DIR` | Backend | No | `<os.tmpdir>/uploads` | Temporary directory for uploaded images | `/tmp/uploads` |
 
 ### Reverse image search sidecar
 
 | Variable | Service | Required | Default | Description | Example |
 |---|---|---|---|---|---|
+| `MODEL_ARTIFACT_SOURCE` | Sidecar + ML Service | No | `gcs` | `local` loads only device files; `gcs` downloads missing cached artifacts | `local` |
 | `FAISS_BUCKET_NAME` | Sidecar | No | `discountmate-ml-models` | GCS bucket containing the FAISS index | `discountmate-ml-models` |
 | `FAISS_OBJECT_NAME` | Sidecar | No | `reverse_image_search.faiss` | GCS object path for the FAISS index file | `reverse_image_search.faiss` |
 | `FAISS_GCP_PROJECT` | Sidecar | No | — | GCP project that owns the FAISS bucket, if different from `GOOGLE_CLOUD_PROJECT` | `other-project-456` |
@@ -311,6 +314,7 @@ Set these in `Backend/.env` for local development. In production, `MONGO_URI` an
 | `ML_SERVICE_PORT` | ML Service | No | `5001` | Port for the Flask service | `5001` |
 | `MONGO_URI` | ML Service | No | — | MongoDB connection string for model endpoints that query the database | `mongodb+srv://...` |
 | `MONGO_DB` | ML Service | No | — | MongoDB database name | `discountmate` |
+| `LOCAL_RAG_INDEX_DIR` | ML Service | No | `recipe_rag/index` (local) or `/tmp/recipe_rag` (GCP) | Directory containing the four Recipe RAG index artifacts | `/data/recipe_rag` |
 
 ---
 
@@ -319,6 +323,8 @@ Set these in `Backend/.env` for local development. In production, `MONGO_URI` an
 ### FAISS index download fails at startup
 
 **Symptom:** `node server.js` exits with `Failed to download FAISS index from gs://discountmate-ml-models/...` and the sidecar never becomes healthy.
+
+This section applies only when `MODEL_ARTIFACT_SOURCE=gcs`. For local development, select `local` and provide `LOCAL_FAISS_PATH`; a missing file disables reverse-image search without stopping the backend.
 
 **Resolution:**
 


### PR DESCRIPTION
# Why
This PR is to support local model load
- Currently, the ML service require fetching model from GCS to local machine to be able to run, so it's failing the whole process if the developer doesn't have access to GCP environment
- The fix is to enable local model reading without a GCP connection

# What changed
- Added env variables to specify the path containing model
- The ml service will read the model locally without depending on GCP connection

# Notes
N/A