### PR TITLE
AD-FE-T1: Replace static homepage modules with API-driven content

### DIFF
--- a/Backend/ml-service/app.py
+++ b/Backend/ml-service/app.py
@@ -17,7 +17,7 @@ from ml_models.weekly_specials import get_weekly_specials_ml
 from ml_models.recommendations import get_recommendations_ml
 from ml_models.price_prediction import get_price_prediction_ml
 from ocr.extractor import process_receipt_internal, build_user_response
-
+from ml_models.trending_categories import get_trending_categories_ml
 
 def _resolve_project_id():
     project_id = (
@@ -186,7 +186,14 @@ def get_current_week():
     today = datetime.now()
     week_start = today - timedelta(days=today.weekday())
     return week_start.strftime('%Y-W%W')
-
+@app.route('/api/trending-categories', methods=['GET'])
+def get_trending_categories():
+    try:
+        limit = int(request.args.get('limit', 3))
+        trending = get_trending_categories_ml(limit=limit)
+        return success_payload(data=trending, count=len(trending))
+    except Exception as e:
+        return error_payload('Failed to fetch trending categories', str(e))
 
 @app.route('/api/ml/recommendations', methods=['POST'])
 def get_recommendations():

--- a/Backend/ml-service/ml_models/trending_categories.py
+++ b/Backend/ml-service/ml_models/trending_categories.py
@@ -1,0 +1,35 @@
+from typing import List, Dict
+
+def get_trending_categories_ml(limit: int = 3) -> List[Dict]:
+    """
+    Get trending category insights.
+    Currently returns placeholder data; ready for real aggregation
+    (e.g. groupby category on real discount data) once available.
+    """
+    trending = [
+        {
+            'category': 'Dairy Products',
+            'avg_price_drop_pct': 23,
+            'avg_savings': 2.40,
+            'trend_label': 'price drop',
+            'description': 'Average savings across milk, cheese, and yogurt',
+            'icon': 'arrow-trend-down',
+        },
+        {
+            'category': 'Household Essentials',
+            'avg_price_drop_pct': None,
+            'avg_savings': None,
+            'trend_label': 'Hot deals',
+            'description': 'Bulk deals on cleaning supplies and paper products',
+            'icon': 'fire',
+        },
+        {
+            'category': 'Fresh Produce',
+            'avg_price_drop_pct': None,
+            'avg_savings': None,
+            'trend_label': 'Price watch',
+            'description': 'Seasonal fruits and vegetables at best prices',
+            'icon': 'chart-line',
+        },
+    ]
+    return trending[:limit]

--- a/Backend/src/controllers/ml.controller.js
+++ b/Backend/src/controllers/ml.controller.js
@@ -1,7 +1,7 @@
-const axios = require('axios');
+const axios = require("axios");
 
 // ML Service URL - can be configured via environment variable
-const ML_SERVICE_URL = process.env.ML_SERVICE_URL || 'http://localhost:5001';
+const ML_SERVICE_URL = process.env.ML_SERVICE_URL || "http://localhost:5001";
 
 /**
  * Get weekly specials from ML service
@@ -18,7 +18,7 @@ const getWeeklySpecials = async (req, res) => {
     // Call Python ML service
     const response = await axios.get(`${ML_SERVICE_URL}/api/weekly-specials`, {
       params,
-      timeout: 10000 // 10 second timeout
+      timeout: 10000, // 10 second timeout
     });
 
     if (response.data.success) {
@@ -26,30 +26,76 @@ const getWeeklySpecials = async (req, res) => {
     } else {
       return res.status(500).json({
         success: false,
-        message: 'ML service returned an error',
-        error: response.data.error
+        message: "ML service returned an error",
+        error: response.data.error,
       });
     }
   } catch (error) {
-    console.error('Error calling ML service:', error.message);
+    console.error("Error calling ML service:", error.message);
 
     // If ML service is unavailable, return a fallback response
-    if (error.code === 'ECONNREFUSED' || error.code === 'ETIMEDOUT') {
+    if (error.code === "ECONNREFUSED" || error.code === "ETIMEDOUT") {
       return res.status(503).json({
         success: false,
-        message: 'ML service is currently unavailable',
-        error: 'Service connection failed. Please ensure the Python ML service is running on port 5001.'
+        message: "ML service is currently unavailable",
+        error:
+          "Service connection failed. Please ensure the Python ML service is running on port 5001.",
       });
     }
 
     return res.status(500).json({
       success: false,
-      message: 'Failed to fetch weekly specials',
-      error: error.message
+      message: "Failed to fetch weekly specials",
+      error: error.message,
     });
   }
 };
+/**
+ * Get trending categories from ML service
+ */
+const getTrendingCategories = async (req, res) => {
+  try {
+    const { limit } = req.query;
 
+    const params = {};
+    if (limit) params.limit = limit;
+
+    const response = await axios.get(
+      `${ML_SERVICE_URL}/api/trending-categories`,
+      {
+        params,
+        timeout: 10000,
+      },
+    );
+
+    if (response.data.success) {
+      return res.json(response.data);
+    } else {
+      return res.status(500).json({
+        success: false,
+        message: "ML service returned an error",
+        error: response.data.error,
+      });
+    }
+  } catch (error) {
+    console.error("Error calling ML service:", error.message);
+
+    if (error.code === "ECONNREFUSED" || error.code === "ETIMEDOUT") {
+      return res.status(503).json({
+        success: false,
+        message: "ML service is currently unavailable",
+        error:
+          "Service connection failed. Please ensure the Python ML service is running on port 5001.",
+      });
+    }
+
+    return res.status(500).json({
+      success: false,
+      message: "Failed to fetch trending categories",
+      error: error.message,
+    });
+  }
+};
 /**
  * Get product recommendations from ML service
  */
@@ -58,7 +104,7 @@ const getRecommendations = async (req, res) => {
     const response = await axios.post(
       `${ML_SERVICE_URL}/api/ml/recommendations`,
       req.body,
-      { timeout: 15000 }
+      { timeout: 15000 },
     );
 
     if (response.data.success) {
@@ -66,25 +112,25 @@ const getRecommendations = async (req, res) => {
     } else {
       return res.status(500).json({
         success: false,
-        message: 'ML service returned an error',
-        error: response.data.error
+        message: "ML service returned an error",
+        error: response.data.error,
       });
     }
   } catch (error) {
-    console.error('Error calling ML recommendations service:', error.message);
+    console.error("Error calling ML recommendations service:", error.message);
 
-    if (error.code === 'ECONNREFUSED' || error.code === 'ETIMEDOUT') {
+    if (error.code === "ECONNREFUSED" || error.code === "ETIMEDOUT") {
       return res.status(503).json({
         success: false,
-        message: 'ML service is currently unavailable',
-        error: 'Service connection failed.'
+        message: "ML service is currently unavailable",
+        error: "Service connection failed.",
       });
     }
 
     return res.status(500).json({
       success: false,
-      message: 'Failed to get recommendations',
-      error: error.message
+      message: "Failed to get recommendations",
+      error: error.message,
     });
   }
 };
@@ -97,7 +143,7 @@ const getPricePrediction = async (req, res) => {
     const response = await axios.post(
       `${ML_SERVICE_URL}/api/ml/price-prediction`,
       req.body,
-      { timeout: 15000 }
+      { timeout: 15000 },
     );
 
     if (response.data.success) {
@@ -105,25 +151,25 @@ const getPricePrediction = async (req, res) => {
     } else {
       return res.status(500).json({
         success: false,
-        message: 'ML service returned an error',
-        error: response.data.error
+        message: "ML service returned an error",
+        error: response.data.error,
       });
     }
   } catch (error) {
-    console.error('Error calling ML price prediction service:', error.message);
+    console.error("Error calling ML price prediction service:", error.message);
 
-    if (error.code === 'ECONNREFUSED' || error.code === 'ETIMEDOUT') {
+    if (error.code === "ECONNREFUSED" || error.code === "ETIMEDOUT") {
       return res.status(503).json({
         success: false,
-        message: 'ML service is currently unavailable',
-        error: 'Service connection failed.'
+        message: "ML service is currently unavailable",
+        error: "Service connection failed.",
       });
     }
 
     return res.status(500).json({
       success: false,
-      message: 'Failed to get price prediction',
-      error: error.message
+      message: "Failed to get price prediction",
+      error: error.message,
     });
   }
 };
@@ -149,18 +195,17 @@ const getPricePrediction = async (req, res) => {
  */
 const getRecipeStats = async (req, res) => {
   try {
-    const response = await axios.get(
-      `${ML_SERVICE_URL}/api/recipe/stats`,
-      { timeout: 5000 }
-    );
+    const response = await axios.get(`${ML_SERVICE_URL}/api/recipe/stats`, {
+      timeout: 5000,
+    });
     return res.json(response.data);
   } catch (error) {
-    console.error('Error calling recipe stats:', error.message);
-    if (error.code === 'ECONNREFUSED' || error.code === 'ETIMEDOUT') {
+    console.error("Error calling recipe stats:", error.message);
+    if (error.code === "ECONNREFUSED" || error.code === "ETIMEDOUT") {
       return res.status(503).json({
         success: false,
-        message: 'ML service is currently unavailable',
-        error: 'Recipe service is not running on port 5001.'
+        message: "ML service is currently unavailable",
+        error: "Recipe service is not running on port 5001.",
       });
     }
     // Forward Flask's error response if it sent one (e.g. 503 RAG_NOT_READY)
@@ -169,8 +214,8 @@ const getRecipeStats = async (req, res) => {
     }
     return res.status(500).json({
       success: false,
-      message: 'Failed to fetch recipe stats',
-      error: error.message
+      message: "Failed to fetch recipe stats",
+      error: error.message,
     });
   }
 };
@@ -181,21 +226,18 @@ const getRecipeStats = async (req, res) => {
  */
 const getRecipeSearch = async (req, res) => {
   try {
-    const response = await axios.get(
-      `${ML_SERVICE_URL}/api/recipe/search`,
-      {
-        params: req.query,   // forward all query params (?q=, ?top_k=)
-        timeout: 10000
-      }
-    );
+    const response = await axios.get(`${ML_SERVICE_URL}/api/recipe/search`, {
+      params: req.query, // forward all query params (?q=, ?top_k=)
+      timeout: 10000,
+    });
     return res.json(response.data);
   } catch (error) {
-    console.error('Error calling recipe search:', error.message);
-    if (error.code === 'ECONNREFUSED' || error.code === 'ETIMEDOUT') {
+    console.error("Error calling recipe search:", error.message);
+    if (error.code === "ECONNREFUSED" || error.code === "ETIMEDOUT") {
       return res.status(503).json({
         success: false,
-        message: 'ML service is currently unavailable',
-        error: 'Recipe service is not running on port 5001.'
+        message: "ML service is currently unavailable",
+        error: "Recipe service is not running on port 5001.",
       });
     }
     if (error.response) {
@@ -203,8 +245,8 @@ const getRecipeSearch = async (req, res) => {
     }
     return res.status(500).json({
       success: false,
-      message: 'Recipe search failed',
-      error: error.message
+      message: "Recipe search failed",
+      error: error.message,
     });
   }
 };
@@ -222,24 +264,24 @@ const postRecipeChat = async (req, res) => {
   try {
     const response = await axios.post(
       `${ML_SERVICE_URL}/api/recipe/chat`,
-      req.body,                 // forward the JSON body verbatim
-      { timeout: 200000 }        // 200 seconds
+      req.body, // forward the JSON body verbatim
+      { timeout: 200000 }, // 200 seconds
     );
     return res.json(response.data);
   } catch (error) {
-    console.error('Error calling recipe chat:', error.message);
-    if (error.code === 'ECONNREFUSED') {
+    console.error("Error calling recipe chat:", error.message);
+    if (error.code === "ECONNREFUSED") {
       return res.status(503).json({
         success: false,
-        message: 'ML service is currently unavailable',
-        error: 'Recipe service is not running on port 5001.'
+        message: "ML service is currently unavailable",
+        error: "Recipe service is not running on port 5001.",
       });
     }
-    if (error.code === 'ETIMEDOUT' || error.code === 'ECONNABORTED') {
+    if (error.code === "ETIMEDOUT" || error.code === "ECONNABORTED") {
       return res.status(504).json({
         success: false,
-        message: 'Recipe chat timed out',
-        error: 'All LLM providers were too slow to respond. Please retry.'
+        message: "Recipe chat timed out",
+        error: "All LLM providers were too slow to respond. Please retry.",
       });
     }
     // Pass Flask's structured error response straight through
@@ -248,8 +290,8 @@ const postRecipeChat = async (req, res) => {
     }
     return res.status(500).json({
       success: false,
-      message: 'Recipe chat failed',
-      error: error.message
+      message: "Recipe chat failed",
+      error: error.message,
     });
   }
 };
@@ -263,15 +305,15 @@ const postRecipeReset = async (req, res) => {
     const response = await axios.post(
       `${ML_SERVICE_URL}/api/recipe/reset`,
       req.body,
-      { timeout: 5000 }
+      { timeout: 5000 },
     );
     return res.json(response.data);
   } catch (error) {
-    console.error('Error calling recipe reset:', error.message);
-    if (error.code === 'ECONNREFUSED' || error.code === 'ETIMEDOUT') {
+    console.error("Error calling recipe reset:", error.message);
+    if (error.code === "ECONNREFUSED" || error.code === "ETIMEDOUT") {
       return res.status(503).json({
         success: false,
-        message: 'ML service is currently unavailable'
+        message: "ML service is currently unavailable",
       });
     }
     if (error.response) {
@@ -279,12 +321,11 @@ const postRecipeReset = async (req, res) => {
     }
     return res.status(500).json({
       success: false,
-      message: 'Recipe reset failed',
-      error: error.message
+      message: "Recipe reset failed",
+      error: error.message,
     });
   }
 };
-
 
 /**
  * GET /api/ml/recipe/products?context_id=...
@@ -293,21 +334,18 @@ const postRecipeReset = async (req, res) => {
  */
 const getRecipeProducts = async (req, res) => {
   try {
-    const response = await axios.get(
-      `${ML_SERVICE_URL}/api/recipe/products`,
-      {
-        params: req.query,   // forwards ?context_id=...
-        timeout: 15000
-      }
-    );
+    const response = await axios.get(`${ML_SERVICE_URL}/api/recipe/products`, {
+      params: req.query, // forwards ?context_id=...
+      timeout: 15000,
+    });
     return res.json(response.data);
   } catch (error) {
-    console.error('Error calling recipe products:', error.message);
-    if (error.code === 'ECONNREFUSED' || error.code === 'ETIMEDOUT') {
+    console.error("Error calling recipe products:", error.message);
+    if (error.code === "ECONNREFUSED" || error.code === "ETIMEDOUT") {
       return res.status(503).json({
         success: false,
-        message: 'ML service is currently unavailable',
-        error: 'Recipe service is not running on port 5001.'
+        message: "ML service is currently unavailable",
+        error: "Recipe service is not running on port 5001.",
       });
     }
     if (error.response) {
@@ -315,15 +353,15 @@ const getRecipeProducts = async (req, res) => {
     }
     return res.status(500).json({
       success: false,
-      message: 'Recipe products fetch failed',
-      error: error.message
+      message: "Recipe products fetch failed",
+      error: error.message,
     });
   }
 };
 
-
 module.exports = {
   getWeeklySpecials,
+  getTrendingCategories,
   getRecommendations,
   getPricePrediction,
   // Recipe RAG
@@ -333,4 +371,3 @@ module.exports = {
   postRecipeReset,
   getRecipeProducts,
 };
-

--- a/Backend/src/routers/ml.router.js
+++ b/Backend/src/routers/ml.router.js
@@ -1,5 +1,5 @@
-const express = require('express');
-const mlController = require('../controllers/ml.controller');
+const express = require("express");
+const mlController = require("../controllers/ml.controller");
 
 const router = express.Router();
 
@@ -28,7 +28,28 @@ const router = express.Router();
  *       503:
  *         description: ML service unavailable
  */
-router.get('/weekly-specials', mlController.getWeeklySpecials);
+router.get("/weekly-specials", mlController.getWeeklySpecials);
+/**
+ * @swagger
+ * /ml/trending-categories:
+ *   get:
+ *     tags: [ML/AI]
+ *     summary: Get trending category insights
+ *     description: Retrieve category-level trending stats (avg price drop, avg savings)
+ *     parameters:
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *           default: 3
+ *         description: Number of categories to return
+ *     responses:
+ *       200:
+ *         description: Trending categories retrieved successfully
+ *       503:
+ *         description: ML service unavailable
+ */
+router.get("/trending-categories", mlController.getTrendingCategories);
 
 /**
  * @swagger
@@ -54,7 +75,7 @@ router.get('/weekly-specials', mlController.getWeeklySpecials);
  *       200:
  *         description: Recommendations retrieved successfully
  */
-router.post('/recommendations', mlController.getRecommendations);
+router.post("/recommendations", mlController.getRecommendations);
 
 /**
  * @swagger
@@ -78,7 +99,7 @@ router.post('/recommendations', mlController.getRecommendations);
  *       200:
  *         description: Price prediction retrieved successfully
  */
-router.post('/price-prediction', mlController.getPricePrediction);
+router.post("/price-prediction", mlController.getPricePrediction);
 
 /* ============================================================
  * Recipe RAG routes (Step 2)
@@ -108,7 +129,7 @@ router.post('/price-prediction', mlController.getPricePrediction);
  *       503:
  *         description: ML service or RAG pipeline unavailable
  */
-router.get('/recipe/stats', mlController.getRecipeStats);
+router.get("/recipe/stats", mlController.getRecipeStats);
 
 /**
  * @swagger
@@ -135,7 +156,7 @@ router.get('/recipe/stats', mlController.getRecipeStats);
  *       503:
  *         description: ML service unavailable
  */
-router.get('/recipe/search', mlController.getRecipeSearch);
+router.get("/recipe/search", mlController.getRecipeSearch);
 
 /**
  * @swagger
@@ -165,7 +186,7 @@ router.get('/recipe/search', mlController.getRecipeSearch);
  *       504:
  *         description: LLM providers timed out
  */
-router.post('/recipe/chat', mlController.postRecipeChat);
+router.post("/recipe/chat", mlController.postRecipeChat);
 
 /**
  * @swagger
@@ -187,7 +208,7 @@ router.post('/recipe/chat', mlController.postRecipeChat);
  *       200:
  *         description: Session reset successfully
  */
-router.post('/recipe/reset', mlController.postRecipeReset);
+router.post("/recipe/reset", mlController.postRecipeReset);
 
 /**
  * @swagger
@@ -215,7 +236,6 @@ router.post('/recipe/reset', mlController.postRecipeReset);
  *       503:
  *         description: ML service unavailable
  */
-router.get('/recipe/products', mlController.getRecipeProducts);
+router.get("/recipe/products", mlController.getRecipeProducts);
 
 module.exports = router;
-

--- a/Frontend/components/home/TrendingInsightsSection.tsx
+++ b/Frontend/components/home/TrendingInsightsSection.tsx
@@ -1,128 +1,177 @@
-import React from "react";
-import { View, Text, Pressable } from "react-native";
+import React, { useState, useEffect } from "react";
+import { View, Text, Pressable, ActivityIndicator } from "react-native";
 import FontAwesome6 from "react-native-vector-icons/FontAwesome6";
+import { API_URL } from "@/constants/Api";
+
+interface TrendingCategory {
+  category: string;
+  avg_price_drop_pct: number | null;
+  avg_savings: number | null;
+  trend_label: string;
+  description: string;
+  icon: string;
+}
+
+interface TrendingResponse {
+  success: boolean;
+  data: TrendingCategory[];
+  count: number;
+  error?: string;
+}
+
+const CARD_THEMES = [
+  {
+    gradientFrom: "from-primary_green/5",
+    gradientTo: "to-secondary_green/5",
+    border: "border-primary_green/20",
+    iconBg: "from-primary_green to-secondary_green",
+    textColor: "text-primary_green",
+  },
+  {
+    gradientFrom: "from-accent/5",
+    gradientTo: "to-accent/10",
+    border: "border-accent/20",
+    iconBg: "from-accent to-orange-400",
+    textColor: "text-accent",
+  },
+  {
+    gradientFrom: "from-blue-50",
+    gradientTo: "to-blue-100",
+    border: "border-blue-200",
+    iconBg: "from-blue-500 to-blue-600",
+    textColor: "text-blue-600",
+  },
+];
 
 export default function TrendingInsightsSection() {
-   return (
-      <View className="bg-white border-t border-gray-100">
-         <View className="w-full max-w-[1920px] mx-auto px-4 md:px-8 py-16">
-            {/* Header */}
-            <View className="mb-10">
-               <Text className="text-3xl font-bold text-[#111827] mb-2">
-                  Trending Insights
-               </Text>
-               <Text className="text-gray-600">
-                  See what's moving in the market this week
-               </Text>
-            </View>
+  const [trending, setTrending] = useState<TrendingCategory[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
-            {/* Cards */}
-            <View className="flex flex-col md:flex-row gap-6">
-               {/* Dairy Products */}
-               <Pressable className="flex-1">
-                  <View className="bg-gradient-to-br from-primary_green/5 to-secondary_green/5 border border-primary_green/20 rounded-2xl p-8 hover:shadow-lg transition-all">
-                     <View className="flex-row items-center justify-between mb-6">
-                        <View className="w-14 h-14 bg-gradient-to-br from-primary_green to-secondary_green rounded-xl flex items-center justify-center shadow-md">
-                           <FontAwesome6
-                              name="arrow-trend-down"
-                              size={20}
-                              color="#FFFFFF"
-                           />
-                        </View>
-                        <Text className="text-sm font-bold text-primary_green">
-                           23% price drop
-                        </Text>
-                     </View>
+  useEffect(() => {
+    fetchTrending();
+  }, []);
 
-                     <Text className="text-xl font-bold text-[#111827] mb-2">
-                        Dairy Products
-                     </Text>
-                     <Text className="text-sm text-gray-600 mb-6">
-                        Average savings of $2.40 across milk, cheese, and yogurt
-                     </Text>
+  const fetchTrending = async () => {
+    try {
+      setLoading(true);
+      setError(null);
 
-                     <Pressable className="flex-row items-center gap-2">
-                        <Text className="text-sm text-primary_green font-semibold">
-                           View all dairy deals
-                        </Text>
+      const response = await fetch(`${API_URL}/ml/trending-categories?limit=3`);
+      const data: TrendingResponse = await response.json();
+
+      if (data.success && data.data) {
+        setTrending(data.data);
+      } else {
+        setError(data.error || "Failed to load trending insights");
+      }
+    } catch (err) {
+      console.error("Error fetching trending categories:", err);
+      setError("Unable to load trending insights.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <View className="bg-white border-t border-gray-100">
+      <View className="w-full max-w-[1920px] mx-auto px-4 md:px-8 py-16">
+        {/* Header */}
+        <View className="mb-10">
+          <Text className="text-3xl font-bold text-[#111827] mb-2">
+            Trending Insights
+          </Text>
+          <Text className="text-gray-600">
+            See what's moving in the market this week
+          </Text>
+        </View>
+
+        {/* Loading State */}
+        {loading && (
+          <View className="flex items-center justify-center py-20">
+            <ActivityIndicator size="large" color="#10B981" />
+            <Text className="mt-4 text-gray-600">Loading trends...</Text>
+          </View>
+        )}
+
+        {/* Error State */}
+        {error && !loading && (
+          <View className="flex items-center justify-center py-20">
+            <Text className="text-red-500 mb-4">{error}</Text>
+            <Pressable
+              onPress={fetchTrending}
+              className="px-6 py-3 rounded-xl bg-[#10B981]"
+            >
+              <Text className="text-white font-semibold">Retry</Text>
+            </Pressable>
+          </View>
+        )}
+
+        {/* Cards */}
+        {!loading && !error && trending.length > 0 && (
+          <View className="flex flex-col md:flex-row gap-6">
+            {trending.map((item, index) => {
+              const theme = CARD_THEMES[index % CARD_THEMES.length];
+              const badgeLabel =
+                item.avg_price_drop_pct != null
+                  ? `${item.avg_price_drop_pct}% price drop`
+                  : item.trend_label;
+
+              return (
+                <Pressable key={item.category} className="flex-1">
+                  <View
+                    className={`bg-gradient-to-br ${theme.gradientFrom} ${theme.gradientTo} border ${theme.border} rounded-2xl p-8 hover:shadow-lg transition-all`}
+                  >
+                    <View className="flex-row items-center justify-between mb-6">
+                      <View
+                        className={`w-14 h-14 bg-gradient-to-br ${theme.iconBg} rounded-xl flex items-center justify-center shadow-md`}
+                      >
                         <FontAwesome6
-                           name="arrow-right"
-                           size={14}
-                           className="text-primary_green"
+                          name={item.icon || "circle-question"}
+                          size={20}
+                          color="#FFFFFF"
                         />
-                     </Pressable>
+                      </View>
+                      <Text className={`text-sm font-bold ${theme.textColor}`}>
+                        {badgeLabel}
+                      </Text>
+                    </View>
+
+                    <Text className="text-xl font-bold text-[#111827] mb-2">
+                      {item.category}
+                    </Text>
+                    <Text className="text-sm text-gray-600 mb-6">
+                      {item.description}
+                    </Text>
+
+                    <Pressable className="flex-row items-center gap-2">
+                      <Text
+                        className={`text-sm ${theme.textColor} font-semibold`}
+                      >
+                        View {item.category} deals
+                      </Text>
+                      <FontAwesome6
+                        name="arrow-right"
+                        size={14}
+                        className={theme.textColor}
+                      />
+                    </Pressable>
                   </View>
-               </Pressable>
+                </Pressable>
+              );
+            })}
+          </View>
+        )}
 
-               {/* Household Essentials */}
-               <Pressable className="flex-1">
-                  <View className="bg-gradient-to-br from-accent/5 to-accent/10 border border-accent/20 rounded-2xl p-8 hover:shadow-lg transition-all">
-                     <View className="flex-row items-center justify-between mb-6">
-                        <View className="w-14 h-14 bg-gradient-to-br from-accent to-orange-400 rounded-xl flex items-center justify-center shadow-md">
-                           <FontAwesome6 name="fire" size={20} color="#FFFFFF" />
-                        </View>
-                        <Text className="text-sm font-bold text-accent">
-                           Hot deals
-                        </Text>
-                     </View>
-
-                     <Text className="text-xl font-bold text-[#111827] mb-2">
-                        Household Essentials
-                     </Text>
-                     <Text className="text-sm text-gray-600 mb-6">
-                        Bulk deals on cleaning supplies and paper products
-                     </Text>
-
-                     <Pressable className="flex-row items-center gap-2">
-                        <Text className="text-sm text-accent font-semibold">
-                           Explore household
-                        </Text>
-                        <FontAwesome6
-                           name="arrow-right"
-                           size={14}
-                           className="text-accent"
-                        />
-                     </Pressable>
-                  </View>
-               </Pressable>
-
-               {/* Fresh Produce */}
-               <Pressable className="flex-1">
-                  <View className="bg-gradient-to-br from-blue-50 to-blue-100 border border-blue-200 rounded-2xl p-8 hover:shadow-lg transition-all">
-                     <View className="flex-row items-center justify-between mb-6">
-                        <View className="w-14 h-14 bg-gradient-to-br from-blue-500 to-blue-600 rounded-xl flex items-center justify-center shadow-md">
-                           <FontAwesome6
-                              name="chart-line"
-                              size={20}
-                              color="#FFFFFF"
-                           />
-                        </View>
-                        <Text className="text-sm font-bold text-blue-600">
-                           Price watch
-                        </Text>
-                     </View>
-
-                     <Text className="text-xl font-bold text-[#111827] mb-2">
-                        Fresh Produce
-                     </Text>
-                     <Text className="text-sm text-gray-600 mb-6">
-                        Seasonal fruits and vegetables at best prices
-                     </Text>
-
-                     <Pressable className="flex-row items-center gap-2">
-                        <Text className="text-sm text-blue-600 font-semibold">
-                           Check fresh produce
-                        </Text>
-                        <FontAwesome6
-                           name="arrow-right"
-                           size={14}
-                           className="text-blue-600"
-                        />
-                     </Pressable>
-                  </View>
-               </Pressable>
-            </View>
-         </View>
+        {/* Empty State */}
+        {!loading && !error && trending.length === 0 && (
+          <View className="flex items-center justify-center py-20">
+            <Text className="text-gray-500">
+              No trending insights available.
+            </Text>
+          </View>
+        )}
       </View>
-   );
+    </View>
+  );
 }


### PR DESCRIPTION
**What was done:**
Investigated all homepage sections in `app/(tabs)/index.tsx` and found `WeeklySpecialsSection` was already API-driven. Identified `TrendingInsightsSection` as the remaining static module (3 hardcoded category cards). No existing endpoint served category-level trending data, so built the full pipeline from scratch:

- `Backend/ml-service/ml_models/trending_categories.py` — new data function, following the same pattern as `weekly_specials.py`
- `GET /api/trending-categories` — new Flask route in `ml-service/app.py`
- `GET /api/ml/trending-categories` — new Express proxy route (`ml.router.js` + `ml.controller.js`), matching the existing `weekly-specials` proxy pattern
- Rewrote `TrendingInsightsSection.tsx` to fetch live data with proper loading/error/empty states, instead of hardcoded JSX

**Testing done:**
- Verified the Python function directly (isolated unit test)
- Verified the full chain via `curl http://localhost:3000/api/ml/trending-categories` — confirmed Node → Python → response works end to end
- Verified in-browser: homepage renders the section correctly from live API data, confirmed via DevTools Network tab

**Known limitation / follow-up:**
The endpoint currently returns structured placeholder data, consistent with how `weekly-specials` is currently implemented in this codebase. Real category-level aggregation (avg price drop / avg savings grouped by category from actual discount data) is a natural follow-up ticket.

**Environment note for the team:**
Local Python setup requires Python 3.10/3.11 specifically — newer versions (3.12+) break several pinned dependencies (pandas, google-auth) via missing prebuilt wheels.