### PR TITLE
feat: add PostgreSQL schema for products and product_pricings (AD-BE-T4)

### DIFF
--- a/Backend/db/schema/products.sql
+++ b/Backend/db/schema/products.sql
@@ -1,0 +1,27 @@
+-- products: one row per unique product, keyed by product_code
+CREATE TABLE products (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    product_code    TEXT NOT NULL UNIQUE,
+    name            TEXT NOT NULL,
+    brand           TEXT,
+    category        TEXT,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_products_category ON products (category);
+CREATE INDEX idx_products_name ON products USING gin (to_tsvector('english', name));
+
+-- product_pricings: one row per price observation, per store chain, per product
+-- Enforces a real FK to products.id -- no legacy product_code fallback matching.
+CREATE TABLE product_pricings (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    product_id      UUID NOT NULL REFERENCES products(id) ON DELETE CASCADE,
+    store_chain     TEXT NOT NULL,  -- e.g. 'coles_generic', 'woolworths_generic', 'iga_generic'
+    price           NUMERIC(10, 2) NOT NULL CHECK (price > 0),
+    observed_date   DATE NOT NULL,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_pricings_product_chain_date
+    ON product_pricings (product_id, store_chain, observed_date DESC);

--- a/Backend/db/schema/products.sql
+++ b/Backend/db/schema/products.sql
@@ -1,27 +1,19 @@
--- products: one row per unique product, keyed by product_code
-CREATE TABLE products (
-    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    product_code    TEXT NOT NULL UNIQUE,
-    name            TEXT NOT NULL,
-    brand           TEXT,
-    category        TEXT,
-    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
-    updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+-- App-owned product metadata only.
+-- Canonical product and pricing data is owned by DE in the `silver` schema
+-- (silver.dim_products, silver.fct_product_prices) — see Adriana's
+-- FINALISED_POSTGRESQL_SCHEMA.md (feature/ad-be-t2-migration-reconciliation).
+-- App Dev does NOT own or duplicate product/pricing tables. This table holds
+-- only presentation/API fields that don't belong in DE's canonical dimension,
+-- joined to silver.dim_products via a shared UUID (logical FK, not physical --
+-- so DE can manage Silver independently).
+
+CREATE TABLE app.product_metadata (
+    product_id          UUID PRIMARY KEY,  -- logical FK to silver.dim_products.id
+    description         TEXT,
+    image_link_primary   TEXT,
+    updated_at           TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
-CREATE INDEX idx_products_category ON products (category);
-CREATE INDEX idx_products_name ON products USING gin (to_tsvector('english', name));
-
--- product_pricings: one row per price observation, per store chain, per product
--- Enforces a real FK to products.id -- no legacy product_code fallback matching.
-CREATE TABLE product_pricings (
-    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    product_id      UUID NOT NULL REFERENCES products(id) ON DELETE CASCADE,
-    store_chain     TEXT NOT NULL,  -- e.g. 'coles_generic', 'woolworths_generic', 'iga_generic'
-    price           NUMERIC(10, 2) NOT NULL CHECK (price > 0),
-    observed_date   DATE NOT NULL,
-    created_at      TIMESTAMPTZ NOT NULL DEFAULT now()
-);
-
-CREATE INDEX idx_pricings_product_chain_date
-    ON product_pricings (product_id, store_chain, observed_date DESC);
+-- Note: image_link_primary remains here until DE and App agree on image
+-- ownership (see FINALISED_POSTGRESQL_SCHEMA.md, "App-owned catalogue
+-- metadata" section). Do not remove pending that decision.


### PR DESCRIPTION
# Why

AD-BE-T4 requires refactoring catalog and product persistence from MongoDB to PostgreSQL. My original design in this PR defined `products` and `product_pricings` tables owned by App Dev. After reviewing Adriana's migration work (`feature/ad-be-t2-migration-reconciliation`, `FINALISED_POSTGRESQL_SCHEMA.md`), I found canonical product/pricing data is actually DE-owned in the `silver` schema — consistent with the DE-09 boundary (App Dev consumes DE's data via shared UUIDs, not a parallel copy).

# What changed

- Replaced the original `products` / `product_pricings` tables with a single `app.product_metadata` table
- Holds only presentation/API fields (description, primary image), joined to `silver.dim_products` via a shared UUID — a logical FK, not physical, so DE can manage Silver independently
- Removed the physical FK design from my original version, since product/pricing history isn't App Dev's to own

# Notes

Supersedes my earlier approach, which unintentionally duplicated DE's canonical data. Credit to Adriana's work for surfacing the correct architecture. `image_link_primary` stays pending a DE/App Dev decision on image ownership.

**Remaining for AD-BE-T4:** schema is correct, but no TypeORM entity or controller exists yet. That needs `typeorm`/`pg` added to the backend (currently MongoDB-only) — a team-level decision, so raising with Sophie/Ben rather than adding unilaterally.